### PR TITLE
Remove switchSubAccountType (dead endpoint)

### DIFF
--- a/src/main/java/voiceit/java/VoiceIt2.java
+++ b/src/main/java/voiceit/java/VoiceIt2.java
@@ -680,14 +680,6 @@ public class VoiceIt2 {
 		}
 	}
 
-	public String switchSubAccountType(String subAccountAPIKey) {
-		try {
-			return EntityUtils.toString(httpClient.execute(
-					new HttpPost(BASE_URL + "/subaccount/" + subAccountAPIKey + "/switchType" + notificationUrl)).getEntity());
-		} catch (Exception e) {
-			return e.getMessage();
-		}
-	}
 
 	public String regenerateSubAccountAPIToken(String subAccountAPIKey) {
 		try {

--- a/src/test/java/TestVoiceIt2.java
+++ b/src/test/java/TestVoiceIt2.java
@@ -205,10 +205,6 @@ class TestVoiceIt2 {
     assertEquals(201, getStatus(ret));
     assertEquals("SUCC", getResponseCode(ret));
 
-    ret = myVoiceIt.switchSubAccountType(unmanagedSubAccountAPIKey);
-    assertEquals(200, getStatus(ret));
-    assertEquals("SUCC", getResponseCode(ret));
-
     // Regenerate Sub Account API Token
     ret = myVoiceIt.regenerateSubAccountAPIToken(unmanagedSubAccountAPIKey);
     assertEquals(200, getStatus(ret));


### PR DESCRIPTION
## Summary
- Removes `switchSubAccountType()` method from `VoiceIt2.java` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)